### PR TITLE
Patch for Ubuntu 22.04

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -17,7 +17,7 @@ endif
 DEFINES =
 WARNINGS = -Wall -W -Wstrict-prototypes -Wmissing-prototypes -Wsystem-headers
 CFLAGS = -g -msoft-float -O0 -fno-omit-frame-pointer -mno-red-zone
-CFLAGS += -mcmodel=large -fno-plt -fno-pic -mno-sse -std=gnu11 -fcommon
+CFLAGS += -mcmodel=large -fno-plt -fno-pic -mno-sse
 CPPFLAGS = -nostdinc -I$(SRCDIR) -I$(SRCDIR)/include/lib -I$(SRCDIR)/include
 CPPFLAGS += -I$(SRCDIR)/include/lib/kernel
 ASFLAGS = -Wa,--gstabs -mcmodel=large

--- a/Make.config
+++ b/Make.config
@@ -17,7 +17,7 @@ endif
 DEFINES =
 WARNINGS = -Wall -W -Wstrict-prototypes -Wmissing-prototypes -Wsystem-headers
 CFLAGS = -g -msoft-float -O0 -fno-omit-frame-pointer -mno-red-zone
-CFLAGS += -mcmodel=large -fno-plt -fno-pic -mno-sse
+CFLAGS += -mcmodel=large -fno-plt -fno-pic -mno-sse -std=gnu11 -fcommon
 CPPFLAGS = -nostdinc -I$(SRCDIR) -I$(SRCDIR)/include/lib -I$(SRCDIR)/include
 CPPFLAGS += -I$(SRCDIR)/include/lib/kernel
 ASFLAGS = -Wa,--gstabs -mcmodel=large

--- a/lib/user/user.lds
+++ b/lib/user/user.lds
@@ -6,8 +6,8 @@ SECTIONS
 {
   /* Read-only sections, merged into text segment: */
   __executable_start = 0x0400000 + SIZEOF_HEADERS;
-  . = 0x0400000 + SIZEOF_HEADERS;
-  .text : AT(0x400000 + SIZEOF_HEADERS) {
+  . = 0x0400000;
+  .text : {
     *(.text)
     *(.note.gnu.build-id)
   } = 0x90

--- a/tests/filesys/base/child-syn-read.c
+++ b/tests/filesys/base/child-syn-read.c
@@ -11,13 +11,13 @@
 #include "tests/lib.h"
 #include "tests/filesys/base/syn-read.h"
 
-const char *test_name = "child-syn-read";
-
 static char buf[BUF_SIZE];
 
 int
 main (int argc, const char *argv[]) 
 {
+  test_name = "child-syn-read";
+
   int child_idx;
   int fd;
   size_t i;

--- a/tests/filesys/extended/child-syn-rw.c
+++ b/tests/filesys/extended/child-syn-rw.c
@@ -13,14 +13,14 @@
 #include "tests/filesys/extended/syn-rw.h"
 #include "tests/lib.h"
 
-const char *test_name = "child-syn-rw";
-
 static char buf1[BUF_SIZE];
 static char buf2[BUF_SIZE];
 
 int
 main (int argc, const char *argv[]) 
 {
+  test_name = "child-syn-rw";
+
   int child_idx;
   int fd;
   size_t ofs;

--- a/tests/userprog/child-close.c
+++ b/tests/userprog/child-close.c
@@ -12,11 +12,11 @@
 #include "tests/userprog/sample.inc"
 #include "tests/lib.h"
 
-const char *test_name = "child-close";
-
 int
 main (int argc UNUSED, char *argv[]) 
 {
+  test_name = "child-close";
+
   msg ("begin");
   
   if (!isdigit (*argv[1]))

--- a/tests/userprog/child-read.c
+++ b/tests/userprog/child-read.c
@@ -14,11 +14,11 @@
 #include "tests/userprog/sample.inc"
 #include "tests/lib.h"
 
-const char *test_name = "child-read";
-
 int
 main (int argc UNUSED, char *argv[]) 
 {
+  test_name = "child-read";
+
   int handle1, handle2;
   int byte_cnt;
   char *buffer;

--- a/tests/userprog/child-rox.c
+++ b/tests/userprog/child-rox.c
@@ -10,8 +10,6 @@
 #include <syscall.h>
 #include "tests/lib.h"
 
-const char *test_name = "child-rox";
-
 static void
 try_write (void) 
 {
@@ -31,6 +29,8 @@ try_write (void)
 int
 main (int argc UNUSED, char *argv[]) 
 {
+  test_name = "child-rox";
+
   msg ("begin");
   try_write ();
 

--- a/tests/userprog/child-simple.c
+++ b/tests/userprog/child-simple.c
@@ -5,10 +5,11 @@
 #include <stdio.h>
 #include "tests/lib.h"
 
-const char *test_name = "child-simple";
 int
 main (void) 
 {
+  test_name = "child-simple";
+
   msg ("run");
   return 81;
 }

--- a/tests/userprog/dup2/dup2-complex.c
+++ b/tests/userprog/dup2/dup2-complex.c
@@ -14,14 +14,14 @@
 #include "tests/userprog/boundary.h"
 #include "tests/userprog/sample.inc"
 
-const char *test_name = "dup2-complex";
-
 char magic[] = {
   "Pintos is funny\n"
 };
 
 int
 main (int argc UNUSED, char *argv[] UNUSED) {
+  test_name = "dup2-complex";
+
   char *buffer;
   int byte_cnt = 0;
   int fd1, fd2, fd3 = 0x1CE, fd4 = 0x1CE - 0xC0FFEE, fd5, fd6;

--- a/tests/userprog/dup2/dup2-simple.c
+++ b/tests/userprog/dup2/dup2-simple.c
@@ -14,10 +14,10 @@
 #include "tests/userprog/boundary.h"
 #include "tests/userprog/sample.inc"
 
-const char *test_name = "dup2-simple";
-
 int
 main (int argc UNUSED, char *argv[] UNUSED) {
+  test_name = "dup2-simple";
+
   char *buffer;
   int byte_cnt = 0;
   int fd1, fd2 = 0x1CE;

--- a/tests/userprog/multi-recurse.c
+++ b/tests/userprog/multi-recurse.c
@@ -7,11 +7,11 @@
 #include <syscall.h>
 #include "tests/lib.h"
 
-const char *test_name = "multi-recurse";
-
 int
 main (int argc UNUSED, char *argv[]) 
 {
+  test_name = "multi-recurse";
+
   int n = atoi (argv[1]);
 
   msg ("begin %d", n);

--- a/tests/userprog/no-vm/multi-oom.c
+++ b/tests/userprog/no-vm/multi-oom.c
@@ -34,8 +34,6 @@
 static const int EXPECTED_DEPTH_TO_PASS = 10;
 static const int EXPECTED_REPETITIONS = 10;
 
-const char *test_name = "multi-oom";
-
 int make_children (void);
 
 /* Open a number of files (and fail to close them).
@@ -141,6 +139,8 @@ make_children (void) {
 
 int
 main (int argc UNUSED, char *argv[] UNUSED) {
+  test_name = "multi-oom";
+
   msg ("begin");
 
   int first_run_depth = make_children ();

--- a/tests/vm/child-linear.c
+++ b/tests/vm/child-linear.c
@@ -7,14 +7,14 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-const char *test_name = "child-linear";
-
 #define SIZE (1024 * 1024)
 static char buf[SIZE];
 
 int
 main (int argc, char *argv[])
 {
+  test_name = "child-linear";
+
   const char *key = argv[argc - 1];
   struct arc4 arc4;
   size_t i;

--- a/tests/vm/child-qsort-mm.c
+++ b/tests/vm/child-qsort-mm.c
@@ -7,11 +7,11 @@
 #include "tests/main.h"
 #include "tests/vm/qsort.h"
 
-const char *test_name = "child-qsort-mm";
-
 int
 main (int argc UNUSED, char *argv[]) 
 {
+  test_name = "child-qsort-mm";
+
   int handle;
   unsigned char *p = (unsigned char *) 0x10000000;
 

--- a/tests/vm/child-qsort.c
+++ b/tests/vm/child-qsort.c
@@ -9,11 +9,11 @@
 #include "tests/main.h"
 #include "tests/vm/qsort.h"
 
-const char *test_name = "child-qsort";
-
 int
 main (int argc UNUSED, char *argv[]) 
 {
+  test_name = "child-qsort";
+
   int handle;
   unsigned char buf[128 * 1024];
   size_t size;

--- a/tests/vm/child-sort.c
+++ b/tests/vm/child-sort.c
@@ -7,14 +7,14 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-const char *test_name = "child-sort";
-
 unsigned char buf[128 * 1024];
 size_t histogram[256];
 
 int
 main (int argc UNUSED, char *argv[]) 
 {
+  test_name = "child-sort";
+
   int handle;
   unsigned char *p;
   size_t size;


### PR DESCRIPTION
- fix for ld
- change test codes not to use multiple definitions for a global variable
